### PR TITLE
code cleanup, fix README trigger examples: first parameter should be list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-
+.PHONY: publish
 publish:
 	python setup.py register
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
-
-.PHONY: publish

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Pusher REST Python library
 
 ![Travis-CI](https://travis-ci.org/pusher/pusher-rest-python.svg)
 
-*status: Alpha*
+![Development Status](https://pypip.in/status/jsonapi/badge.svg)
 
 This is the new python library that will replace the "pusher" module once it
 becomes stable enough.
@@ -46,14 +46,14 @@ You can then trigger events to channels. Channel and event names may only
 contain alphanumeric characters, `-` and `_`:
 
 ```python
-pusher.trigger('a_channel', 'an_event', {'some': 'data'})
+pusher.trigger(['a_channel'], 'an_event', {'some': 'data'})
 ```
 
 You can also specify `socket_id` as a separate argument, as described in
 <http://pusher.com/docs/duplicates>:
 
 ```python
-pusher.trigger('a_channel', 'an_event', {'some': 'data'}, socket_id)
+pusher.trigger(['a_channel'], 'an_event', {'some': 'data'}, socket_id)
 ```
 
 ### Additional options
@@ -72,4 +72,3 @@ License
 -------
 
 Copyright (c) 2014 Pusher Ltd. See LICENSE for details.
-

--- a/pusher/config.py
+++ b/pusher/config.py
@@ -28,7 +28,7 @@ class Config(object):
     :param app_id: The Pusher application ID
     :param key: The Pusher application key
     :param secret: The Pusher application secret
-    :param ssl: Whenever to use SSL or plain HTTP 
+    :param ssl: Whenever to use SSL or plain HTTP
     :param host: Used for custom host destination
     :param port: Used for custom port destination
     :param cluster: Convention for other clusters than the main Pusher-one.


### PR DESCRIPTION
Also added pipin status to README. It is taken from setup.py, so, you do not need to handle it in both places.
